### PR TITLE
Fix clone url of opus

### DIFF
--- a/script/build.sh
+++ b/script/build.sh
@@ -10,7 +10,7 @@ hg clone https://bitbucket.org/multicoreware/x265
 git clone --depth 1 git://github.com/mstorsjo/fdk-aac.git
 git clone --depth 1 https://chromium.googlesource.com/webm/libvpx
 git clone --depth 1 git://source.ffmpeg.org/ffmpeg
-git clone --depth 1 git://git.opus-codec.org/opus.git
+git clone https://git.xiph.org/opus.git
 git clone --depth 1 https://github.com/mulx/aacgain.git
 
 # Build L-SMASH


### PR DESCRIPTION
Resolve #3

git.opus-codec.org isn't available now. Use git.xiph.org instead.

I had the following error, so removed `--depth` option.

```
❯ git clone --depth 1 https://git.xiph.org/opus.git
Cloning into 'opus'...
fatal: dumb http transport does not support --depth
```